### PR TITLE
Events ingestor per conn remove out

### DIFF
--- a/event/event_connect.go
+++ b/event/event_connect.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ilgianlu/tagyou/conf"
 	"github.com/ilgianlu/tagyou/model"
-	"github.com/ilgianlu/tagyou/out"
 	"github.com/ilgianlu/tagyou/packet"
 	"github.com/ilgianlu/tagyou/persistence"
 )
@@ -26,7 +25,7 @@ func onConnect(connections *model.Connections, p *packet.Packet) {
 	startSession(p.Session)
 
 	connack := packet.Connack(false, packet.CONNECT_OK, p.Session.GetProtocolVersion())
-	out.SimpleSend(connections, clientId, connack.ToByteSlice())
+	SimpleSend(connections, clientId, connack.ToByteSlice())
 }
 
 func doAuth(session *model.RunningSession) bool {
@@ -69,7 +68,7 @@ func checkConnectionTakeOver(p *packet.Packet, connections *model.Connections) b
 	}
 
 	pkt := packet.Connack(false, packet.SESSION_TAKEN_OVER, protocolVersion)
-	out.SimpleSend(connections, clientId, pkt.ToByteSlice())
+	SimpleSend(connections, clientId, pkt.ToByteSlice())
 
 	err := connections.Close(clientId)
 	if err != nil {

--- a/event/event_publish.go
+++ b/event/event_publish.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ilgianlu/tagyou/conf"
 	"github.com/ilgianlu/tagyou/model"
-	"github.com/ilgianlu/tagyou/out"
 	"github.com/ilgianlu/tagyou/packet"
 	"github.com/ilgianlu/tagyou/persistence"
 	"github.com/rs/zerolog/log"
@@ -37,7 +36,7 @@ func onPublish(connections *model.Connections, p *packet.Packet) {
 
 func sendAck(connections *model.Connections, p *packet.Packet, reasonCode uint8) {
 	puback := packet.Puback(p.PacketIdentifier(), reasonCode, p.Session.ProtocolVersion)
-	out.SimpleSend(connections, p.Session.ClientId, puback.ToByteSlice())
+	SimpleSend(connections, p.Session.ClientId, puback.ToByteSlice())
 }
 
 func sendPubrec(connections *model.Connections, p *packet.Packet, reasonCode uint8) {
@@ -57,5 +56,5 @@ func sendPubrec(connections *model.Connections, p *packet.Packet, reasonCode uin
 	persistence.RetryRepository.SaveOne(r)
 
 	pubrec := packet.Pubrec(p.PacketIdentifier(), reasonCode, protocolVersion)
-	out.SimpleSend(connections, clientId, pubrec.ToByteSlice())
+	SimpleSend(connections, clientId, pubrec.ToByteSlice())
 }

--- a/event/event_pubrec.go
+++ b/event/event_pubrec.go
@@ -9,13 +9,10 @@ import (
 	"github.com/ilgianlu/tagyou/persistence"
 )
 
-func clientPubrec(p *packet.Packet, outQueue chan<- out.OutData) {
+func clientPubrec(connections *model.Connections, p *packet.Packet) {
 	sendPubrel := func(retry model.Retry) {
-		var o out.OutData
-		o.ClientId = retry.ClientId
 		toSend := packet.Pubrel(retry.PacketIdentifier, retry.ReasonCode, p.Session.ProtocolVersion)
-		o.Packet = toSend.ToByteSlice()
-		outQueue <- o
+		out.SimpleSend(connections, retry.ClientId, toSend.ToByteSlice())
 	}
 
 	onExpectedPubrec := func(retry model.Retry) {

--- a/event/event_pubrec.go
+++ b/event/event_pubrec.go
@@ -4,7 +4,6 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/ilgianlu/tagyou/model"
-	"github.com/ilgianlu/tagyou/out"
 	"github.com/ilgianlu/tagyou/packet"
 	"github.com/ilgianlu/tagyou/persistence"
 )
@@ -12,7 +11,7 @@ import (
 func clientPubrec(connections *model.Connections, p *packet.Packet) {
 	sendPubrel := func(retry model.Retry) {
 		toSend := packet.Pubrel(retry.PacketIdentifier, retry.ReasonCode, p.Session.ProtocolVersion)
-		out.SimpleSend(connections, retry.ClientId, toSend.ToByteSlice())
+		SimpleSend(connections, retry.ClientId, toSend.ToByteSlice())
 	}
 
 	onExpectedPubrec := func(retry model.Retry) {

--- a/event/event_pubrel.go
+++ b/event/event_pubrel.go
@@ -9,13 +9,10 @@ import (
 	"github.com/ilgianlu/tagyou/persistence"
 )
 
-func clientPubrel(p *packet.Packet, outQueue chan<- out.OutData) {
+func clientPubrel(connections *model.Connections, p *packet.Packet) {
 	sendPubcomp := func(retry model.Retry) {
-		var o out.OutData
-		o.ClientId = p.Session.GetClientId()
 		toSend := packet.Pubcomp(p.PacketIdentifier(), retry.ReasonCode, p.Session.ProtocolVersion)
-		o.Packet = toSend.ToByteSlice()
-		outQueue <- o
+		out.SimpleSend(connections, p.Session.GetClientId(), toSend.ToByteSlice())
 	}
 
 	onExpectedPubrel := func(retry model.Retry) {

--- a/event/event_pubrel.go
+++ b/event/event_pubrel.go
@@ -4,7 +4,6 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/ilgianlu/tagyou/model"
-	"github.com/ilgianlu/tagyou/out"
 	"github.com/ilgianlu/tagyou/packet"
 	"github.com/ilgianlu/tagyou/persistence"
 )
@@ -12,7 +11,7 @@ import (
 func clientPubrel(connections *model.Connections, p *packet.Packet) {
 	sendPubcomp := func(retry model.Retry) {
 		toSend := packet.Pubcomp(p.PacketIdentifier(), retry.ReasonCode, p.Session.ProtocolVersion)
-		out.SimpleSend(connections, p.Session.GetClientId(), toSend.ToByteSlice())
+		SimpleSend(connections, p.Session.GetClientId(), toSend.ToByteSlice())
 	}
 
 	onExpectedPubrel := func(retry model.Retry) {

--- a/event/event_subscribe.go
+++ b/event/event_subscribe.go
@@ -3,7 +3,6 @@ package event
 import (
 	"github.com/ilgianlu/tagyou/conf"
 	"github.com/ilgianlu/tagyou/model"
-	"github.com/ilgianlu/tagyou/out"
 	"github.com/ilgianlu/tagyou/packet"
 	"github.com/ilgianlu/tagyou/persistence"
 )
@@ -20,7 +19,7 @@ func onSubscribe(connections *model.Connections, p *packet.Packet) {
 func clientSubscribed(connections *model.Connections, p *packet.Packet, reasonCodes []uint8) {
 	p.Session.Mu.RLock()
 	toSend := packet.Suback(p.PacketIdentifier(), reasonCodes, p.Session.ProtocolVersion)
-	out.SimpleSend(connections, p.Session.ClientId, toSend.ToByteSlice())
+	SimpleSend(connections, p.Session.ClientId, toSend.ToByteSlice())
 	p.Session.Mu.RUnlock()
 }
 
@@ -49,6 +48,6 @@ func sendRetain(connections *model.Connections, protocolVersion uint8, subscript
 	}
 	for _, r := range retains {
 		p := packet.Publish(protocolVersion, subscription.Qos, true, r.Topic, packet.NewPacketIdentifier(), r.ApplicationMessage)
-		out.SimpleSend(connections, subscription.ClientId, p.ToByteSlice())
+		SimpleSend(connections, subscription.ClientId, p.ToByteSlice())
 	}
 }

--- a/event/event_subscribe.go
+++ b/event/event_subscribe.go
@@ -8,28 +8,23 @@ import (
 	"github.com/ilgianlu/tagyou/persistence"
 )
 
-func onSubscribe(p *packet.Packet, outQueue chan<- out.OutData) {
+func onSubscribe(connections *model.Connections, p *packet.Packet) {
 	reasonCodes := []uint8{}
 	for _, subscription := range p.Subscriptions {
-		rCode := clientSubscription(p.Session, subscription, outQueue)
+		rCode := clientSubscription(connections, p.Session, subscription)
 		reasonCodes = append(reasonCodes, rCode)
 	}
-	clientSubscribed(p, reasonCodes, outQueue)
+	clientSubscribed(connections, p, reasonCodes)
 }
 
-func clientSubscribed(p *packet.Packet, reasonCodes []uint8, outQueue chan<- out.OutData) {
+func clientSubscribed(connections *model.Connections, p *packet.Packet, reasonCodes []uint8) {
 	p.Session.Mu.RLock()
-	clientId := p.Session.ClientId
-	protocolVersion := p.Session.ProtocolVersion
+	toSend := packet.Suback(p.PacketIdentifier(), reasonCodes, p.Session.ProtocolVersion)
+	out.SimpleSend(connections, p.Session.ClientId, toSend.ToByteSlice())
 	p.Session.Mu.RUnlock()
-	var o out.OutData
-	o.ClientId = clientId
-	toSend := packet.Suback(p.PacketIdentifier(), reasonCodes, protocolVersion)
-	o.Packet = toSend.ToByteSlice()
-	outQueue <- o
 }
 
-func clientSubscription(session *model.RunningSession, subscription model.Subscription, outQueue chan<- out.OutData) uint8 {
+func clientSubscription(connections *model.Connections, session *model.RunningSession, subscription model.Subscription) uint8 {
 	session.Mu.RLock()
 	fromLocalhost := session.FromLocalhost()
 	subscribeAcl := session.SubscribeAcl
@@ -42,18 +37,18 @@ func clientSubscription(session *model.RunningSession, subscription model.Subscr
 	// db.Create(&subscription)
 	persistence.SubscriptionRepository.CreateOne(subscription)
 	if !subscription.Shared {
-		sendRetain(protocolVersion, subscription, outQueue)
+		sendRetain(connections, protocolVersion, subscription)
 	}
 	return 0
 }
 
-func sendRetain(protocolVersion uint8, subscription model.Subscription, outQueue chan<- out.OutData) {
+func sendRetain(connections *model.Connections, protocolVersion uint8, subscription model.Subscription) {
 	retains := persistence.RetainRepository.FindRetains(subscription.Topic)
 	if len(retains) == 0 {
 		return
 	}
 	for _, r := range retains {
 		p := packet.Publish(protocolVersion, subscription.Qos, true, r.Topic, packet.NewPacketIdentifier(), r.ApplicationMessage)
-		sendSimple(subscription.ClientId, &p, outQueue)
+		out.SimpleSend(connections, subscription.ClientId, p.ToByteSlice())
 	}
 }

--- a/event/event_unsubscribe.go
+++ b/event/event_unsubscribe.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ilgianlu/tagyou/conf"
 	"github.com/ilgianlu/tagyou/model"
-	"github.com/ilgianlu/tagyou/out"
 	"github.com/ilgianlu/tagyou/packet"
 	"github.com/ilgianlu/tagyou/persistence"
 )
@@ -21,7 +20,7 @@ func onUnsubscribe(connections *model.Connections, p *packet.Packet) {
 
 func clientUnsubscribed(connections *model.Connections, p *packet.Packet, reasonCodes []uint8) {
 	toSend := packet.Unsuback(p.PacketIdentifier(), reasonCodes, p.Session.GetProtocolVersion())
-	out.SimpleSend(connections, p.Session.GetClientId(), toSend.ToByteSlice())
+	SimpleSend(connections, p.Session.GetClientId(), toSend.ToByteSlice())
 }
 
 func clientUnsubscription(clientId string, unsub model.Subscription) uint8 {

--- a/event/event_unsubscribe.go
+++ b/event/event_unsubscribe.go
@@ -10,21 +10,18 @@ import (
 	"github.com/ilgianlu/tagyou/persistence"
 )
 
-func onUnsubscribe(p *packet.Packet, outQueue chan<- out.OutData) {
+func onUnsubscribe(connections *model.Connections, p *packet.Packet) {
 	reasonCodes := []uint8{}
 	for _, unsub := range p.Subscriptions {
 		rCode := clientUnsubscription(p.Session.GetClientId(), unsub)
 		reasonCodes = append(reasonCodes, rCode)
 	}
-	clientUnsubscribed(p, reasonCodes, outQueue)
+	clientUnsubscribed(connections, p, reasonCodes)
 }
 
-func clientUnsubscribed(p *packet.Packet, reasonCodes []uint8, outQueue chan<- out.OutData) {
-	var o out.OutData
-	o.ClientId = p.Session.GetClientId()
+func clientUnsubscribed(connections *model.Connections, p *packet.Packet, reasonCodes []uint8) {
 	toSend := packet.Unsuback(p.PacketIdentifier(), reasonCodes, p.Session.GetProtocolVersion())
-	o.Packet = toSend.ToByteSlice()
-	outQueue <- o
+	out.SimpleSend(connections, p.Session.GetClientId(), toSend.ToByteSlice())
 }
 
 func clientUnsubscription(clientId string, unsub model.Subscription) uint8 {

--- a/event/event_will.go
+++ b/event/event_will.go
@@ -1,13 +1,13 @@
 package event
 
 import (
-	"github.com/ilgianlu/tagyou/out"
+	"github.com/ilgianlu/tagyou/model"
 	"github.com/ilgianlu/tagyou/packet"
 	"github.com/ilgianlu/tagyou/persistence"
 	"github.com/rs/zerolog/log"
 )
 
-func sendWill(p *packet.Packet, outQueue chan<- out.OutData) {
+func sendWill(connections *model.Connections, p *packet.Packet) {
 	p.Session.Mu.RLock()
 	defer p.Session.Mu.RUnlock()
 	if p.Session.WillTopic != "" {
@@ -16,7 +16,7 @@ func sendWill(p *packet.Packet, outQueue chan<- out.OutData) {
 			return
 		}
 		willPacket := packet.Publish(p.Session.ProtocolVersion, p.Session.WillQoS(), p.Session.WillRetain(), p.Session.WillTopic, packet.NewPacketIdentifier(), p.Session.WillMessage)
-		sendForward(p.Session.WillTopic, &willPacket, outQueue)
+		sendForward(connections, p.Session.WillTopic, &willPacket)
 	}
 }
 

--- a/event/events.go
+++ b/event/events.go
@@ -76,8 +76,8 @@ func clientDisconnect(p *packet.Packet, connections *model.Connections, clientId
 
 func sendForward(connections *model.Connections, topic string, p *packet.Packet) {
 	destSubs := tpc.Explode(topic)
-	go sendSubscribers(connections, topic, destSubs, p)
-	go sendSharedSubscribers(connections, topic, destSubs, p)
+	sendSubscribers(connections, topic, destSubs, p)
+	sendSharedSubscribers(connections, topic, destSubs, p)
 }
 
 func sendSubscribers(connections *model.Connections, topic string, destSubs []string, p *packet.Packet) {

--- a/event/events.go
+++ b/event/events.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ilgianlu/tagyou/conf"
 	"github.com/ilgianlu/tagyou/model"
-	"github.com/ilgianlu/tagyou/out"
 	"github.com/ilgianlu/tagyou/packet"
 	"github.com/ilgianlu/tagyou/persistence"
 	tpc "github.com/ilgianlu/tagyou/topic"
@@ -60,7 +59,7 @@ func RangeEvents(connections *model.Connections, events <-chan *packet.Packet) {
 
 func onPing(connections *model.Connections, p *packet.Packet) {
 	toSend := packet.PingResp()
-	out.SimpleSend(connections, p.Session.GetClientId(), toSend.ToByteSlice())
+	SimpleSend(connections, p.Session.GetClientId(), toSend.ToByteSlice())
 }
 
 func clientDisconnect(p *packet.Packet, connections *model.Connections, clientId string) {
@@ -93,7 +92,7 @@ func send(connections *model.Connections, topic string, s model.Subscription, p 
 	if qos == conf.QOS0 {
 		// prepare publish packet qos 0 no packet identifier
 		p := packet.Publish(s.ProtocolVersion, conf.QOS0, p.Retain(), topic, 0, p.ApplicationMessage())
-		out.SimpleSend(connections, s.ClientId, p.ToByteSlice())
+		SimpleSend(connections, s.ClientId, p.ToByteSlice())
 	} else if qos == conf.QOS1 {
 		// prepare publish packet qos 1 (if sub permit) new packet identifier
 		p := packet.Publish(s.ProtocolVersion, qos, p.Retain(), topic, packet.NewPacketIdentifier(), p.ApplicationMessage())
@@ -107,7 +106,7 @@ func send(connections *model.Connections, topic string, s model.Subscription, p 
 			CreatedAt:          time.Now().Unix(),
 		}
 		persistence.RetryRepository.SaveOne(r)
-		out.SimpleSend(connections, r.ClientId, p.ToByteSlice())
+		SimpleSend(connections, r.ClientId, p.ToByteSlice())
 	} else if qos == 2 {
 		// prepare publish packet qos 2 (if sub permit) new packet identifier
 		p := packet.Publish(s.ProtocolVersion, qos, p.Retain(), topic, packet.NewPacketIdentifier(), p.ApplicationMessage())
@@ -121,7 +120,7 @@ func send(connections *model.Connections, topic string, s model.Subscription, p 
 			CreatedAt:          time.Now().Unix(),
 		}
 		persistence.RetryRepository.SaveOne(r)
-		out.SimpleSend(connections, r.ClientId, p.ToByteSlice())
+		SimpleSend(connections, r.ClientId, p.ToByteSlice())
 	}
 }
 

--- a/event/events.go
+++ b/event/events.go
@@ -14,43 +14,43 @@ import (
 	tpc "github.com/ilgianlu/tagyou/topic"
 )
 
-func RangeEvents(connections *model.Connections, events <-chan *packet.Packet, outQueue chan<- out.OutData) {
+func RangeEvents(connections *model.Connections, events <-chan *packet.Packet) {
 	for p := range events {
 		clientId := p.Session.GetClientId()
 		switch p.Event {
 		case packet.EVENT_CONNECT:
 			log.Debug().Msgf("//!! EVENT type %d client connect %s", p.Event, clientId)
-			onConnect(connections, p, outQueue)
+			onConnect(connections, p)
 		case packet.EVENT_SUBSCRIBED:
 			log.Debug().Msgf("//!! EVENT type %d client subscribed %s", p.Event, clientId)
-			onSubscribe(p, outQueue)
+			onSubscribe(connections, p)
 		case packet.EVENT_UNSUBSCRIBED:
 			log.Debug().Msgf("//!! EVENT type %d client unsubscribed %s", p.Event, clientId)
-			onUnsubscribe(p, outQueue)
+			onUnsubscribe(connections, p)
 		case packet.EVENT_PUBLISH:
 			log.Debug().Msgf("//!! EVENT type %d client published to %s %s QoS %d", p.Event, p.Topic, clientId, p.QoS())
-			onPublish(p, outQueue)
+			onPublish(connections, p)
 		case packet.EVENT_PUBACKED:
 			log.Debug().Msgf("//!! EVENT type %d client acked message %d %s", p.Event, p.PacketIdentifier(), clientId)
 			clientPuback(p)
 		case packet.EVENT_PUBRECED:
 			log.Debug().Msgf("//!! EVENT type %d pub received message %d %s", p.Event, p.PacketIdentifier(), clientId)
-			clientPubrec(p, outQueue)
+			clientPubrec(connections, p)
 		case packet.EVENT_PUBRELED:
 			log.Debug().Msgf("//!! EVENT type %d pub releases message %d %s", p.Event, p.PacketIdentifier(), clientId)
-			clientPubrel(p, outQueue)
+			clientPubrel(connections, p)
 		case packet.EVENT_PUBCOMPED:
 			log.Debug().Msgf("//!! EVENT type %d pub complete message %d %s", p.Event, p.PacketIdentifier(), clientId)
 			clientPubcomp(p)
 		case packet.EVENT_PING:
 			log.Debug().Msgf("//!! EVENT type %d client ping %s", p.Event, clientId)
-			onPing(p, outQueue)
+			onPing(connections, p)
 		case packet.EVENT_DISCONNECT:
 			log.Debug().Msgf("//!! EVENT type %d client disconnect %s", p.Event, clientId)
 			clientDisconnect(p, connections, clientId)
 		case packet.EVENT_WILL_SEND:
 			log.Debug().Msgf("//!! EVENT type %d sending will message %s", p.Event, clientId)
-			sendWill(p, outQueue)
+			sendWill(connections, p)
 		case packet.EVENT_PACKET_ERR:
 			log.Debug().Msgf("//!! EVENT type %d packet error %s", p.Event, clientId)
 			clientDisconnect(p, connections, clientId)
@@ -58,12 +58,9 @@ func RangeEvents(connections *model.Connections, events <-chan *packet.Packet, o
 	}
 }
 
-func onPing(p *packet.Packet, outQueue chan<- out.OutData) {
-	var o out.OutData
-	o.ClientId = p.Session.GetClientId()
+func onPing(connections *model.Connections, p *packet.Packet) {
 	toSend := packet.PingResp()
-	o.Packet = toSend.ToByteSlice()
-	outQueue <- o
+	out.SimpleSend(connections, p.Session.GetClientId(), toSend.ToByteSlice())
 }
 
 func clientDisconnect(p *packet.Packet, connections *model.Connections, clientId string) {
@@ -78,25 +75,25 @@ func clientDisconnect(p *packet.Packet, connections *model.Connections, clientId
 	}
 }
 
-func sendForward(topic string, p *packet.Packet, outQueue chan<- out.OutData) {
+func sendForward(connections *model.Connections, topic string, p *packet.Packet) {
 	destSubs := tpc.Explode(topic)
-	go sendSubscribers(topic, destSubs, p, outQueue)
-	go sendSharedSubscribers(topic, destSubs, p, outQueue)
+	go sendSubscribers(connections, topic, destSubs, p)
+	go sendSharedSubscribers(connections, topic, destSubs, p)
 }
 
-func sendSubscribers(topic string, destSubs []string, p *packet.Packet, outQueue chan<- out.OutData) {
+func sendSubscribers(connections *model.Connections, topic string, destSubs []string, p *packet.Packet) {
 	subs := persistence.SubscriptionRepository.FindSubscriptions(destSubs, false)
 	for _, s := range subs {
-		send(topic, s, p, outQueue)
+		send(connections, topic, s, p)
 	}
 }
 
-func send(topic string, s model.Subscription, p *packet.Packet, outQueue chan<- out.OutData) {
+func send(connections *model.Connections, topic string, s model.Subscription, p *packet.Packet) {
 	qos := getQos(p.QoS(), s.Qos)
 	if qos == conf.QOS0 {
 		// prepare publish packet qos 0 no packet identifier
 		p := packet.Publish(s.ProtocolVersion, conf.QOS0, p.Retain(), topic, 0, p.ApplicationMessage())
-		sendSimple(s.ClientId, &p, outQueue)
+		out.SimpleSend(connections, s.ClientId, p.ToByteSlice())
 	} else if qos == conf.QOS1 {
 		// prepare publish packet qos 1 (if sub permit) new packet identifier
 		p := packet.Publish(s.ProtocolVersion, qos, p.Retain(), topic, packet.NewPacketIdentifier(), p.ApplicationMessage())
@@ -110,7 +107,7 @@ func send(topic string, s model.Subscription, p *packet.Packet, outQueue chan<- 
 			CreatedAt:          time.Now().Unix(),
 		}
 		persistence.RetryRepository.SaveOne(r)
-		sendSimple(r.ClientId, &p, outQueue)
+		out.SimpleSend(connections, r.ClientId, p.ToByteSlice())
 	} else if qos == 2 {
 		// prepare publish packet qos 2 (if sub permit) new packet identifier
 		p := packet.Publish(s.ProtocolVersion, qos, p.Retain(), topic, packet.NewPacketIdentifier(), p.ApplicationMessage())
@@ -124,16 +121,16 @@ func send(topic string, s model.Subscription, p *packet.Packet, outQueue chan<- 
 			CreatedAt:          time.Now().Unix(),
 		}
 		persistence.RetryRepository.SaveOne(r)
-		sendSimple(r.ClientId, &p, outQueue)
+		out.SimpleSend(connections, r.ClientId, p.ToByteSlice())
 	}
 }
 
-func sendSharedSubscribers(topic string, destSubs []string, p *packet.Packet, outQueue chan<- out.OutData) {
+func sendSharedSubscribers(connections *model.Connections, topic string, destSubs []string, p *packet.Packet) {
 	subs := persistence.SubscriptionRepository.FindOrderedSubscriptions(destSubs, true, "share_name")
 	grouped := groupSubscribers(subs)
 	for _, group := range grouped {
 		dest := pickDest(group, 1)
-		send(topic, dest, p, outQueue)
+		send(connections, topic, dest, p)
 	}
 }
 
@@ -167,13 +164,6 @@ func getQos(pubQos uint8, subQos uint8) uint8 {
 	} else {
 		return pubQos
 	}
-}
-
-func sendSimple(clientId string, p *packet.Packet, outQueue chan<- out.OutData) {
-	var o out.OutData
-	o.ClientId = clientId
-	o.Packet = p.ToByteSlice()
-	outQueue <- o
 }
 
 func saveRetain(p *packet.Packet) {

--- a/event/out.go
+++ b/event/out.go
@@ -1,4 +1,4 @@
-package out
+package event
 
 import (
 	"github.com/rs/zerolog/log"

--- a/out/out_data.go
+++ b/out/out_data.go
@@ -1,6 +1,0 @@
-package out
-
-type OutData struct {
-	ClientId string
-	Packet   []byte
-}

--- a/out/out_queue.go
+++ b/out/out_queue.go
@@ -6,13 +6,7 @@ import (
 	"github.com/ilgianlu/tagyou/model"
 )
 
-func RangeOutQueue(connections *model.Connections, outQueue <-chan OutData) {
-	for o := range outQueue {
-		simpleSend(connections, o.ClientId, o.Packet)
-	}
-}
-
-func simpleSend(connections *model.Connections, clientId string, p []byte) {
+func SimpleSend(connections *model.Connections, clientId string, p []byte) {
 	conn, exists := connections.Exists(clientId)
 	if exists {
 		if conn == nil {


### PR DESCRIPTION
- have one events ingestor per connection instead of one share between all connections
- remove out message ingestor, send directly messages in event ingestor

* ingestor is subroutine ranging event channel, managing packet replies