### PR TITLE
avoid useless locking of session

### DIFF
--- a/engine/connect.go
+++ b/engine/connect.go
@@ -31,11 +31,9 @@ func (s StandardEngine) OnConnect(session *model.RunningSession) {
 }
 
 func doAuth(session *model.RunningSession) bool {
-	session.Mu.RLock()
 	clientId := session.ClientId
 	username := session.Username
 	sessionPassword := session.Password
-	session.Mu.RUnlock()
 	ok, pubAcl, subAcl := checkAuth(clientId, username, sessionPassword)
 	if !ok {
 		slog.Debug("[MQTT] wrong connect credentials")
@@ -61,10 +59,8 @@ func checkAuth(clientId string, username string, sessionPassword string) (bool, 
 }
 
 func checkConnectionTakeOver(session *model.RunningSession) bool {
-	session.Mu.RLock()
 	clientId := session.ClientId
 	protocolVersion := session.ProtocolVersion
-	session.Mu.RUnlock()
 	if !session.Router.DestinationExists(clientId) {
 		return false
 	}

--- a/engine/publish.go
+++ b/engine/publish.go
@@ -42,8 +42,6 @@ func sendAck(session *model.RunningSession, packetIdentifier int, reasonCode uin
 }
 
 func sendPubrec(session *model.RunningSession, p model.Packet, reasonCode uint8) {
-	session.Mu.RLock()
-	defer session.Mu.RUnlock()
 	clientId := session.ClientId
 	protocolVersion := session.ProtocolVersion
 	r := model.Retry{

--- a/engine/subscribe.go
+++ b/engine/subscribe.go
@@ -17,15 +17,11 @@ func (s StandardEngine) OnSubscribe(session *model.RunningSession, p model.Packe
 }
 
 func clientSubscribed(session *model.RunningSession, packetIdentifier int, reasonCodes []uint8) {
-	session.Mu.RLock()
 	toSend := packet.Suback(packetIdentifier, reasonCodes, session.ProtocolVersion)
 	session.Router.Send(session.ClientId, toSend.ToByteSlice())
-	session.Mu.RUnlock()
 }
 
 func clientSubscription(session *model.RunningSession, subscription model.Subscription) uint8 {
-	session.Mu.RLock()
-	defer session.Mu.RUnlock()
 	fromLocalhost := session.FromLocalhost()
 	subscribeAcl := session.SubscribeAcl
 	protocolVersion := session.ProtocolVersion

--- a/engine/will.go
+++ b/engine/will.go
@@ -9,8 +9,6 @@ import (
 )
 
 func sendWill(session *model.RunningSession) {
-	session.Mu.RLock()
-	defer session.Mu.RUnlock()
 	if session.WillTopic != "" {
 		slog.Debug("[MQTT] will topic was set")
 		needWillSend := needWillSend(session)

--- a/model/running_session.go
+++ b/model/running_session.go
@@ -37,8 +37,6 @@ func (s *RunningSession) ReservedBit() bool {
 }
 
 func (s *RunningSession) CleanStart() bool {
-	s.Mu.RLock()
-	defer s.Mu.RUnlock()
 	return (s.ConnectFlags & 0x02) > 0
 }
 
@@ -67,70 +65,48 @@ func (s *RunningSession) FromLocalhost() bool {
 }
 
 func (s *RunningSession) GetClientId() string {
-	s.Mu.RLock()
-	defer s.Mu.RUnlock()
 	return s.ClientId
 }
 
 func (s *RunningSession) GetProtocolVersion() uint8 {
-	s.Mu.RLock()
-	defer s.Mu.RUnlock()
 	return s.ProtocolVersion
 }
 
 func (s *RunningSession) GetConn() TagyouConn {
-	s.Mu.RLock()
-	defer s.Mu.RUnlock()
 	return s.Conn
 }
 
 func (s *RunningSession) GetKeepAlive() int {
-	s.Mu.RLock()
-	defer s.Mu.RUnlock()
 	return s.KeepAlive
 }
 
 func (s *RunningSession) GetLastSeen() int64 {
-	s.Mu.RLock()
-	defer s.Mu.RUnlock()
 	return s.LastSeen
 }
 
 func (s *RunningSession) GetLastConnect() int64 {
-	s.Mu.RLock()
-	defer s.Mu.RUnlock()
 	return s.LastConnect
 }
 
 func (s *RunningSession) GetExpiryInterval() int64 {
-	s.Mu.RLock()
-	defer s.Mu.RUnlock()
 	return s.ExpiryInterval
 }
 
 func (s *RunningSession) GetConnected() bool {
-	s.Mu.RLock()
-	defer s.Mu.RUnlock()
 	return s.Connected
 }
 
 func (s *RunningSession) SetConnected(connected bool) {
-	s.Mu.Lock()
 	s.Connected = connected
-	s.Mu.Unlock()
 }
 
 func (s *RunningSession) ApplyAcl(pubAcl string, subAcl string) {
-	s.Mu.Lock()
 	s.PublishAcl = pubAcl
 	s.SubscribeAcl = subAcl
-	s.Mu.Unlock()
 }
 
 func (s *RunningSession) ApplySessionId(sessionID int64) {
-	s.Mu.Lock()
 	s.SessionID = sessionID
-	s.Mu.Unlock()
 }
 
 func (s *RunningSession) Expired() bool {

--- a/mqtt/range.go
+++ b/mqtt/range.go
@@ -2,6 +2,7 @@ package mqtt
 
 import (
 	"log/slog"
+	"time"
 
 	"github.com/ilgianlu/tagyou/model"
 	"github.com/ilgianlu/tagyou/packet"
@@ -14,6 +15,7 @@ func rangePackets(session *model.RunningSession, packets <-chan *packet.Packet) 
 }
 
 func managePacket(session *model.RunningSession, p model.Packet) {
+	defer time.Sleep(100 * time.Millisecond)
 	slog.Debug("//!! is session connected?", "connected?", session.GetConnected())
 	slog.Debug("//!! packet arriving", "packet-type", p.PacketType())
 	if !session.GetConnected() && p.PacketType() != packet.PACKET_TYPE_CONNECT {

--- a/packet/connect.go
+++ b/packet/connect.go
@@ -15,8 +15,6 @@ func Connect() Packet {
 }
 
 func (p *Packet) connectReq(session *model.RunningSession) int {
-	session.Mu.Lock()
-	defer session.Mu.Unlock()
 	// START VARIABLE HEADER
 	i := 0
 	pl := Read2BytesInt(p.remainingBytes, i)

--- a/packet/subscribe.go
+++ b/packet/subscribe.go
@@ -10,8 +10,6 @@ import (
 )
 
 func (p *Packet) subscribeReq(session *model.RunningSession) int {
-	session.Mu.RLock()
-	defer session.Mu.RUnlock()
 	// variable header
 	i := 2 // 2 bytes for packet identifier
 	if session.ProtocolVersion >= conf.MQTT_V5 {

--- a/packet/unsubscribe.go
+++ b/packet/unsubscribe.go
@@ -9,8 +9,6 @@ import (
 )
 
 func (p *Packet) unsubscribeReq(session *model.RunningSession) int {
-	session.Mu.RLock()
-	defer session.Mu.RUnlock()
 	i := 2 // 2 bytes for packet identifier
 	if session.ProtocolVersion >= conf.MQTT_V5 {
 		pl, err := p.parseProperties(i)

--- a/sqlrepository/session.go
+++ b/sqlrepository/session.go
@@ -40,8 +40,6 @@ func mappingSessions(sessions []dbaccess.Session) []model.Session {
 }
 
 func (sr SessionSqlRepository) PersistSession(running *model.RunningSession) (int64, error) {
-	running.Mu.RLock()
-	defer running.Mu.RUnlock()
 	var connectd int64 = 0
 	if running.Connected {
 		connectd = 1
@@ -59,8 +57,6 @@ func (sr SessionSqlRepository) PersistSession(running *model.RunningSession) (in
 }
 
 func (sr SessionSqlRepository) UpdateSession(sessionId int64, running *model.RunningSession) (int64, error) {
-	running.Mu.RLock()
-	defer running.Mu.RUnlock()
 	var connectd int64 = 0
 	if running.Connected {
 		connectd = 1


### PR DESCRIPTION
locking is useless on this application architecture. events channel ensure that session is read or written from one goroutine at a time